### PR TITLE
Resolve slate isCollapsed TypeError

### DIFF
--- a/src/components/SlateEditor/utils/SlateUtilityFunctions.js
+++ b/src/components/SlateEditor/utils/SlateUtilityFunctions.js
@@ -1,4 +1,4 @@
-import { Editor, Transforms, Element as SlateElement } from 'slate'
+import { Editor, Transforms, Element as SlateElement, Range } from 'slate'
 import {useSlateStatic} from 'slate-react'
 import Link from'../Elements/Link/Link'
 import Image from '../Elements/Embed/Image'
@@ -30,7 +30,7 @@ export const toggleBlock = (editor,format)=>{
     const isAligned = alignment.some(alignmentType => isBlockActive(editor,alignmentType))
     
     const { selection } = editor
-    const isCollapsed = selection && Editor.isCollapsed(editor, selection)
+    const isCollapsed = selection && Range.isCollapsed(selection)
     
     // Check if this is a heading format
     const isHeading = ['headingOne', 'headingTwo', 'headingThree'].includes(format)


### PR DESCRIPTION
Fix TypeError by using `Range.isCollapsed` instead of `Editor.isCollapsed`.

The `Editor.isCollapsed` method does not exist in the Slate.js API