### PR TITLE
Implement custom font size controller

### DIFF
--- a/src/components/SlateEditor/Elements/FontSize/FontSize.css
+++ b/src/components/SlateEditor/Elements/FontSize/FontSize.css
@@ -1,0 +1,118 @@
+.font-size-picker {
+  position: relative;
+  display: inline-block;
+}
+
+.font-size-button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  height: 30px;
+  min-width: 60px;
+  transition: all 0.2s ease;
+}
+
+.font-size-button:hover {
+  background-color: #f5f5f5;
+  border-color: #999;
+}
+
+.font-size-value {
+  font-weight: 500;
+}
+
+.font-size-arrow {
+  font-size: 10px;
+  color: #666;
+}
+
+.font-size-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  z-index: 1000;
+  min-width: 120px;
+}
+
+.font-size-list {
+  max-height: 300px;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.font-size-option {
+  padding: 6px 16px;
+  cursor: pointer;
+  font-size: 14px;
+  transition: background-color 0.2s ease;
+}
+
+.font-size-option:hover {
+  background-color: #f0f0f0;
+}
+
+.font-size-option.active {
+  background-color: #e3f2fd;
+  font-weight: 500;
+}
+
+.custom-size-section {
+  border-top: 1px solid #e0e0e0;
+  padding: 8px;
+}
+
+.custom-size-section form {
+  display: flex;
+  gap: 4px;
+}
+
+.custom-size-input {
+  flex: 1;
+  padding: 4px 8px;
+  border: 1px solid #ddd;
+  border-radius: 3px;
+  font-size: 13px;
+  width: 60px;
+}
+
+.custom-size-input:focus {
+  outline: none;
+  border-color: #2196F3;
+}
+
+.custom-size-btn {
+  padding: 4px 12px;
+  background-color: #2196F3;
+  color: white;
+  border: none;
+  border-radius: 3px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.custom-size-btn:hover {
+  background-color: #1976D2;
+}
+
+/* Hide spinner arrows for number input */
+.custom-size-input::-webkit-inner-spin-button,
+.custom-size-input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.custom-size-input[type=number] {
+  -moz-appearance: textfield;
+}

--- a/src/components/SlateEditor/Elements/FontSize/FontSize.jsx
+++ b/src/components/SlateEditor/Elements/FontSize/FontSize.jsx
@@ -1,0 +1,135 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { useSlate } from 'slate-react';
+import { addMarkData, activeMark } from '../../utils/SlateUtilityFunctions';
+import './FontSize.css';
+
+const FontSize = () => {
+  const editor = useSlate();
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [customSize, setCustomSize] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const dropdownRef = useRef(null);
+
+  // Predefined font sizes in pixels
+  const fontSizes = [
+    { label: '8', value: '8px' },
+    { label: '10', value: '10px' },
+    { label: '12', value: '12px' },
+    { label: '14', value: '14px' },
+    { label: '16', value: '16px' },
+    { label: '18', value: '18px' },
+    { label: '20', value: '20px' },
+    { label: '24', value: '24px' },
+    { label: '28', value: '28px' },
+    { label: '32', value: '32px' },
+    { label: '36', value: '36px' },
+    { label: '40', value: '40px' },
+    { label: '48', value: '48px' },
+    { label: '56', value: '56px' },
+    { label: '64', value: '64px' },
+    { label: '72', value: '72px' },
+  ];
+
+  // Get current font size
+  const currentSize = activeMark(editor, 'fontSize');
+  
+  // Convert current size to display format
+  const getDisplaySize = () => {
+    if (!currentSize || currentSize === 'normal') return '16';
+    
+    // Check if it's one of the old format sizes
+    const oldSizeMap = {
+      small: '12',
+      normal: '16',
+      medium: '28',
+      huge: '40'
+    };
+    
+    if (oldSizeMap[currentSize]) {
+      return oldSizeMap[currentSize];
+    }
+    
+    // Extract numeric value from px string
+    const match = currentSize.match(/(\d+)/);
+    return match ? match[1] : '16';
+  };
+
+  const handleSizeChange = (size) => {
+    addMarkData(editor, { format: 'fontSize', value: size });
+    setShowDropdown(false);
+  };
+
+  const handleCustomSize = (e) => {
+    e.preventDefault();
+    const size = parseInt(customSize);
+    if (size && size >= 8 && size <= 200) {
+      handleSizeChange(`${size}px`);
+      setCustomSize('');
+    }
+  };
+
+  // Handle click outside to close dropdown
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setShowDropdown(false);
+      }
+    };
+
+    if (showDropdown) {
+      document.addEventListener('mousedown', handleClickOutside);
+      return () => {
+        document.removeEventListener('mousedown', handleClickOutside);
+      };
+    }
+  }, [showDropdown]);
+
+  return (
+    <div className="font-size-picker" ref={dropdownRef}>
+      <button
+        className="font-size-button"
+        onClick={() => setShowDropdown(!showDropdown)}
+        onMouseDown={(e) => e.preventDefault()}
+      >
+        <span className="font-size-value">{getDisplaySize()}</span>
+        <span className="font-size-arrow">▼</span>
+      </button>
+
+      {showDropdown && (
+        <div className="font-size-dropdown">
+          <div className="font-size-list">
+            {fontSizes.map((size) => (
+              <div
+                key={size.value}
+                className={`font-size-option ${currentSize === size.value ? 'active' : ''}`}
+                onClick={() => handleSizeChange(size.value)}
+                onMouseDown={(e) => e.preventDefault()}
+              >
+                {size.label}
+              </div>
+            ))}
+          </div>
+          
+          <div className="custom-size-section">
+            <form onSubmit={handleCustomSize}>
+              <input
+                type="number"
+                placeholder="Custom"
+                value={customSize}
+                onChange={(e) => setCustomSize(e.target.value)}
+                min="8"
+                max="200"
+                className="custom-size-input"
+              />
+              <button type="submit" className="custom-size-btn">
+                OK
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FontSize;

--- a/src/components/SlateEditor/Toolbar/Toolbar.jsx
+++ b/src/components/SlateEditor/Toolbar/Toolbar.jsx
@@ -16,6 +16,7 @@ import Id from '../Elements/ID/Id'
 import TableContextMenu from '../Elements/TableContextMenu/TableContextMenu'
 import CodeToTextButton from '../Elements/CodeToText/CodeToTextButton'
 import HtmlContextMenu from '../Elements/CodeToText/HtmlContextMenu';
+import FontSize from '../Elements/FontSize/FontSize'
 const Toolbar = (props)=>{
     const {handleCodeToText} = props
     const editor = useSlate();
@@ -94,6 +95,8 @@ const Toolbar = (props)=>{
                                             return <MarkButton key={element.id} {...element}/>
                                         case 'dropdown':
                                             return <Dropdown key={element.id} {...element} />
+                                        case 'font-size':
+                                            return <FontSize key={element.id} />
                                         case 'link':
                                             return <LinkButton key={element.id} active={isBlockActive(editor,'link')} editor={editor}/>
                                         case 'embed':

--- a/src/components/SlateEditor/Toolbar/toolbarGroups.js
+++ b/src/components/SlateEditor/Toolbar/toolbarGroups.js
@@ -9,8 +9,7 @@ const toolbarGroups = [
         {
             id:2,
             format:'fontSize',
-            type:'dropdown',
-            options:[{text:'Small',value:'small'},{text:'Normal',value:'normal'},{text:'Medium',value:'medium'},{text:'Huge',value:'huge'}]
+            type:'font-size'
         }
     ],
     [

--- a/src/components/SlateEditor/Toolbar/toolbarIcons/fontSize.svg
+++ b/src/components/SlateEditor/Toolbar/toolbarIcons/fontSize.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 13V3h1.5v4.25H8V3h1.5v10H8V8.75H3.5V13H2z" fill="currentColor"/>
+  <path d="M11 11V6h1v2h2v-2h1v5h-1V9h-2v2h-1z" fill="currentColor"/>
+</svg>

--- a/src/components/SlateEditor/utils/SlateUtilityFunctions.js
+++ b/src/components/SlateEditor/utils/SlateUtilityFunctions.js
@@ -163,7 +163,7 @@ export const activeMark = (editor,format) =>{
     const defaultMarkData = {
         color:'black',
         bgColor:'black',
-        fontSize:'normal',
+        fontSize:'16px',
         fontFamily:'sans'
     } 
     const marks = Editor.marks(editor);
@@ -202,7 +202,9 @@ export const getMarked = (leaf,children) =>{
         children = <span style={{backgroundColor:leaf.bgColor}}>{children}</span>
     }
     if(leaf.fontSize){
-        const size = sizeMap[leaf.fontSize]
+        // Check if it's a pixel value or old format
+        const isPixelValue = typeof leaf.fontSize === 'string' && leaf.fontSize.includes('px');
+        const size = isPixelValue ? leaf.fontSize : sizeMap[leaf.fontSize] || leaf.fontSize;
         children = <span style={{fontSize:size}}>{children}</span>
     }
     if(leaf.fontFamily){


### PR DESCRIPTION
Add a custom font size controller to the rich text editor.

This PR replaces the existing limited font size dropdown with a new controller that offers a wider range of predefined pixel sizes (8px-72px) and allows users to input custom pixel values (8px-200px). It also ensures backward compatibility with previously saved 'small', 'normal', 'medium', 'huge' font sizes.